### PR TITLE
Save status property on the saved currentSpec

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/laflaneuse/protractor-html-reporter-with-retry/issues"
   },
   "peerDependencies": {
-    "jasmine": "^2.4.1"
+    "jasmine": "^3.6.2"
   },
   "license": "MIT"
 }

--- a/reporter.js
+++ b/reporter.js
@@ -127,6 +127,9 @@ class Reporter {
     };
 
     specDone(result) {
+        if (this.currentSpec.id === result.id) {
+            this.currentSpec.status = result.status;
+        }
         this.counts[this.currentSpec.status] = (this.counts[this.currentSpec.status] || 0) + 1;
         this.sequence.push(this.currentSpec);
 


### PR DESCRIPTION
Due to the following code:
```javascript
specStarted(result) {
...
    this.currentSpec = result;
...
};
```
javascript does not save the object reference but its value. Later, jasmine will run this code before `specDone`
```javascript
    var complete = {
      fn: function(done) {
        if (self.autoCleanClosures) {
          self.queueableFn.fn = null;
        }
        self.result.status = self.status(excluded, failSpecWithNoExp);
        self.result.duration = self.timer.elapsed();
        self.resultCallback(self.result, done);
      }
    };
```
To have the status information, I saved the `status`  value in the `currentSpec` object.