### PR TITLE
[protractor-html-reporter-with-retry] Exclude trailing punctuation fr…

### DIFF
--- a/report.html
+++ b/report.html
@@ -294,7 +294,7 @@
         return function (text) {
             if (!text) return text;
             var escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            var linked = escaped.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank">$1</a>');
+            var linked = escaped.replace(/(https?:\/\/\S*[^\s.,;:!?)\]}>])/g, '<a href="$1" target="_blank">$1</a>');
             return $sce.trustAsHtml(linked);
         };
     });


### PR DESCRIPTION
…om linkify match

Summary:
Exclude trailing punctuation from link.

+

add .arcconfig for Freelancer Phabricator

Test Plan:
[] With this diff, the full stop is not part of the second link |Before|After|
|{F4817869}|{F4817870}|

Reviewers: anebbs

Subscribers: oemokpae

Tags: #platform_performance

Differential Revision: https://phabricator.tools.flnltd.com/D224583